### PR TITLE
removed unnecessary JSON encoding

### DIFF
--- a/plugins/urbandictionary.py
+++ b/plugins/urbandictionary.py
@@ -1,4 +1,3 @@
-import json
 import requests
 
 
@@ -17,12 +16,12 @@ def run(msg):
             response = requests.get(searchurl)
             result = response.json()
 
-            word = json.dumps(result['list'][0]['word'])
-            definition = json.dumps(result['list'][0]['definition'])
-            example = json.dumps(result['list'][0]['example'])
+            word = result['list'][0]['word']
+            definition = result['list'][0]['definition']
+            example = result['list'][0]['example']
 
-            definitionresult = str(word) + ": " + str(definition)
-            exampleresult = "example: " + str(example)
+            definitionresult = word + ": " + definition
+            exampleresult = "example: " + example
 
             definition_to_send = {'action': 'send_msg', 'payload': definitionresult}
             example_to_send = {'action': 'send_msg', 'payload': exampleresult}


### PR DESCRIPTION
`response.json()` gives us nice, normal Python strings to work with and I'm thinking there's no reason to use `json.dumps` to turn these back into JSON-formatted strings.
This is where escape sequences like "\n" are being introduced.

Also, wrapping strings in `str()` does nothing so I've taken that out too.