### PR TITLE
sticking your nose2 where it doesn't belong

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,7 @@
+[flake8]
+ignore = E128, E402, F403, E501
+#  E128: continuation line under-indented
+#  E402: module level import not at top of file
+#  F403: wildcard module imports
+#  E501: Line length > 80 characters
+show-source = True

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,8 @@ python:
 install:
   - pip install -r requirements.txt
   - pip install flake8
+  - pip install nose2
 
-# Flake8 tests. We ignore the following rules:
-#  E128: continuation line under-indented
-#  E402: module level import not at top of file
-#  F403: wildcard module imports
-#  E501: Line length > 80 characters
-script: flake8 --ignore=E128,E402,F403,E501 --show-source *.py helpers plugins
+script:
+  - flake8
+  - nose2


### PR DESCRIPTION
The first thing I've changed is to move our settings for flake8 into its own configuration file. This lets you quickly check for formatting issues by running flake8 from the command line before committing your changes and going to the trouble of creating a pull request. :ok_hand:

The second thing I've changed is to add nose2 to the Travis CI configuration file. I checked that the file is still valid YAML using Travis CI's online validator. nose2 doesn't appear to need configuration at this point, by default it just finds tests and runs them. Right now it'll run the two tests in 'test_plugins_eightball.py' and find that everything is OK. (Or at least it should, because that's what's happening on my computer.)

From here I leave it up to the capable @justingood to make sure nothing is accidentally set aflame. :grin: 